### PR TITLE
add city to top widget

### DIFF
--- a/pdxchambers-weather.php
+++ b/pdxchambers-weather.php
@@ -80,7 +80,7 @@ class pdxchambers_weather extends WP_Widget {
 		<?php
 		}
 		echo $args['after_widget'];
-		$topHTML = '<div id="pdxc-top-weather" style="background-color: black; color: white; display: ' .$displayTop . '; margin-right: 30px; text-align: right;">Current Temperature: ' . $temp . $units . '</div>';
+		$topHTML = '<div id="pdxc-top-weather" style="background-color: black; color: white; display: ' .$displayTop . '; margin-right: 30px; text-align: right;">Current Temperature in ' . $instance['cityCode'] . ': ' . $temp . $units . '</div>';
 		echo $topHTML;
 	}
 


### PR DESCRIPTION
Adds city name to top widget label to clarify where the displayed temperature applies to. The original labeling left this information out which added ambiguity as to whether the temperature was local to the user agent viewing the page or the location of the website owner.

Fixes Issue #1 